### PR TITLE
pointing to assets

### DIFF
--- a/hybrid_django_react/copy_assets.py
+++ b/hybrid_django_react/copy_assets.py
@@ -1,12 +1,10 @@
 import os
 from distutils.dir_util import copy_tree
-
+from pathlib import Path
 
 def copy_assets_to_current_dir():
-    file_path = os.path.realpath(__file__)
-    assets_path = os.path.join(file_path, "../assets")
+    file_path = Path(__file__).resolve().parent
+    assets_path = f'{file_path}/assets'
     files = os.listdir(assets_path)
-
     current_directory_path = os.getcwd()
-
     copy_tree(assets_path, current_directory_path)


### PR DESCRIPTION
the original file_path pointed to the .py script and ran following command :
os.path.join(file_path, "../assets") trying to point to the the previous folder didn't work.

Creating a string with the path did work 